### PR TITLE
Add backend-dispatcher capabilities for JPEG2000

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,131 @@ To use it, just use ``import hdf5plugin`` and supported compression filters are 
 
 For details, see `Usage documentation <http://www.silx.org/doc/hdf5plugin/latest/usage.html>`_.
 
+
+JPEG2000 backend model
+----------------------
+
+This branch adds an experimental ``Jpeg2000`` HDF5 filter with a backend
+selection layer.  The HDF5 filter itself is installed as a normal hdf5plugin
+filter in::
+
+    hdf5plugin/plugins/libh5jpeg2000.so
+
+Backend implementations are deliberately kept separate from HDF5 filters.  A
+backend is not registered with HDF5 directly; it is loaded by the JPEG2000
+filter dispatcher when needed.  Optional backends are installed below a
+plugin-specific backend directory, for example::
+
+    hdf5plugin/backends/jpeg2000/libh5jpeg2000_kakadu_backend.so
+
+This keeps the file format stable while allowing different sites to use
+different JPEG2000 engines.  Files compressed with the JPEG2000 filter do not
+record whether OpenJPEG or Kakadu was used.  A reader can use any compatible
+backend available in its own process.
+
+The current backend policy is:
+
+* ``openjpeg`` is the built-in fallback backend of ``libh5jpeg2000.so``.
+* ``kakadu`` is an optional backend library loaded with ``dlopen``.
+* Kakadu libraries are not bundled in the Python package or wheel.
+* If Kakadu is selected but its runtime libraries are not reachable through
+  ``LD_LIBRARY_PATH``, the backend is not used.
+* In ``auto`` mode, the packaged manifest can prefer Kakadu and fall back to
+  OpenJPEG when Kakadu cannot be loaded.
+
+Runtime backend selection can be done in Python::
+
+    import hdf5plugin
+
+    hdf5plugin.Jpeg2000.configure_backend("auto")     # manifest/default policy
+    hdf5plugin.Jpeg2000.configure_backend("openjpeg") # force OpenJPEG
+    hdf5plugin.Jpeg2000.configure_backend("kakadu")   # force Kakadu
+
+or with environment variables::
+
+    export HDF5PLUGIN_JPEG2000_BACKEND=kakadu
+    export HDF5PLUGIN_JPEG2000_BACKEND=openjpeg
+    export HDF5PLUGIN_JPEG2000_BACKEND=auto
+
+The packaged manifest is ``hdf5plugin_jpeg2000_plugins.json``.  A custom
+manifest can be selected with::
+
+    export HDF5PLUGIN_JPEG2000_MANIFEST=/path/to/hdf5plugin_jpeg2000_plugins.json
+
+Kakadu test procedure used in this development environment
+----------------------------------------------------------
+
+The following commands assume the same environment used during development:
+
+* source tree: ``/data/scisofttmp/mirone/PROJECTS/segmentation/NR/hdf5plugin_thomas``
+* test virtual environment: ``/data/scisofttmp/mirone/environments/hdf5plugin_jpeg2000_test``
+* Kakadu installation already present in: ``/data/scisofttmp/mirone/KD``
+* OpenJPEG pkg-config from the NightRail development environment
+
+Copy-paste build and install::
+
+    cd /data/scisofttmp/mirone/PROJECTS/segmentation/NR/hdf5plugin_thomas
+
+    source /data/scisofttmp/mirone/environments/hdf5plugin_jpeg2000_test/bin/activate
+
+    export PKG_CONFIG_PATH=/cvmfs/tomo.esrf.fr/software/packages/ubuntu24.04/x86_64/nightraildev/26_06_01/lib/pkgconfig
+    export KDIR=/data/scisofttmp/mirone/KD
+    export HDF5PLUGIN_STRIP=blosc,blosc2,bshuf,bzip2,fcidecomp,lz4,sperr,sz,sz3,zfp,zstd
+
+    python -m pip install --no-build-isolation --force-reinstall .
+
+Check that the main HDF5 filter does not link Kakadu directly::
+
+    ldd /data/scisofttmp/mirone/environments/hdf5plugin_jpeg2000_test/lib/python3.12/site-packages/hdf5plugin/plugins/libh5jpeg2000.so
+
+The output should list OpenJPEG but not ``libkdu_*``.  The optional backend is
+separate and should show unresolved Kakadu libraries unless ``LD_LIBRARY_PATH``
+contains the Kakadu lib directory::
+
+    ldd /data/scisofttmp/mirone/environments/hdf5plugin_jpeg2000_test/lib/python3.12/site-packages/hdf5plugin/backends/jpeg2000/libh5jpeg2000_kakadu_backend.so
+
+Run the normal hdf5plugin tests without Kakadu in ``LD_LIBRARY_PATH``.  This
+checks that the package remains usable and falls back to OpenJPEG::
+
+    export LD_LIBRARY_PATH=/cvmfs/tomo.esrf.fr/software/packages/ubuntu24.04/x86_64/nightraildev/26_06_01/lib
+    python -m unittest hdf5plugin.test
+
+Run an explicit Kakadu roundtrip by adding Kakadu to ``LD_LIBRARY_PATH``::
+
+    export LD_LIBRARY_PATH=/data/scisofttmp/mirone/KD/lib:/cvmfs/tomo.esrf.fr/software/packages/ubuntu24.04/x86_64/nightraildev/26_06_01/lib
+
+    python - <<'PY'
+    import os
+    import tempfile
+
+    import h5py
+    import hdf5plugin
+    import numpy as np
+
+    hdf5plugin.Jpeg2000.configure_backend("kakadu")
+
+    path = tempfile.NamedTemporaryFile(suffix=".h5", delete=False).name
+    try:
+        data = (np.arange(64 * 96, dtype=np.uint16).reshape(64, 96) % 2048)
+        with h5py.File(path, "w") as h5:
+            h5.create_dataset(
+                "data",
+                data=data,
+                compression=hdf5plugin.Jpeg2000(compression_ratio=1.0),
+            )
+        with h5py.File(path, "r") as h5:
+            out = h5["data"][()]
+        np.testing.assert_array_equal(out, data)
+        print("kakadu_roundtrip_ok")
+    finally:
+        os.unlink(path)
+    PY
+
+To debug backend selection, enable dispatcher diagnostics::
+
+    export HDF5PLUGIN_JPEG2000_DEBUG=1
+
+
 License
 -------
 

--- a/README.rst
+++ b/README.rst
@@ -58,13 +58,16 @@ backend available in its own process.
 
 The current backend policy is:
 
-* ``openjpeg`` is the built-in fallback backend of ``libh5jpeg2000.so``.
-* ``kakadu`` is an optional backend library loaded with ``dlopen``.
+* ``libh5jpeg2000.so`` is backend-neutral and does not link OpenJPEG or Kakadu.
+* ``openjpeg`` is an optional backend library built only when OpenJPEG
+  development files are available through pkg-config.
+* ``kakadu`` is an optional backend library built when the Kakadu headers and
+  libraries are pointed to by ``KDIR``/``KAKADU_ROOT``.
 * Kakadu libraries are not bundled in the Python package or wheel.
-* If Kakadu is selected but its runtime libraries are not reachable through
-  ``LD_LIBRARY_PATH``, the backend is not used.
+* If a backend is selected but its runtime libraries are not reachable through
+  ``LD_LIBRARY_PATH``, that backend is not used.
 * In ``auto`` mode, the packaged manifest can prefer Kakadu and fall back to
-  OpenJPEG when Kakadu cannot be loaded.
+  OpenJPEG when both backends are available.
 
 Runtime backend selection can be done in Python::
 
@@ -98,7 +101,6 @@ already present in ``/data/scisofttmp/mirone/KD``.
 * branch: ``jpeg2000``
 * temporary workdir and virtual environment: under ``/tmp``
 * Kakadu installation already present in: ``/data/scisofttmp/mirone/KD``
-* OpenJPEG discovered through pkg-config from the NightRail development stack
 
 Copy-paste full source quickstart::
 
@@ -114,13 +116,12 @@ Copy-paste full source quickstart::
     git clone --branch jpeg2000 https://github.com/alemirone/hdf5plugin_thomas.git
     cd hdf5plugin_thomas
 
-    export PKG_CONFIG_PATH=/cvmfs/tomo.esrf.fr/software/packages/ubuntu24.04/x86_64/nightraildev/26_06_01/lib/pkgconfig
     export KDIR=/data/scisofttmp/mirone/KD
     export HDF5PLUGIN_STRIP=blosc,blosc2,bshuf,bzip2,fcidecomp,lz4,sperr,sz,sz3,zfp,zstd
 
     python -m pip install --no-build-isolation --force-reinstall .
 
-Check that the main HDF5 filter does not link Kakadu directly::
+Check that the main HDF5 filter does not link any JPEG2000 backend directly::
 
     JPEG2000_FILTER="$(python - <<'PY'
     from pathlib import Path
@@ -131,9 +132,9 @@ Check that the main HDF5 filter does not link Kakadu directly::
 
     ldd "$JPEG2000_FILTER"
 
-The output should list OpenJPEG but not ``libkdu_*``.  The optional backend is
-separate and should show unresolved Kakadu libraries unless ``LD_LIBRARY_PATH``
-contains the Kakadu lib directory::
+The output should not list OpenJPEG or ``libkdu_*``.  The optional Kakadu
+backend is separate and should show unresolved Kakadu libraries unless
+``LD_LIBRARY_PATH`` contains the Kakadu lib directory::
 
     KAKADU_BACKEND="$(python - <<'PY'
     from pathlib import Path
@@ -144,15 +145,9 @@ contains the Kakadu lib directory::
 
     ldd "$KAKADU_BACKEND"
 
-Run the normal hdf5plugin tests without Kakadu in ``LD_LIBRARY_PATH``.  This
-checks that the package remains usable and falls back to OpenJPEG::
-
-    export LD_LIBRARY_PATH=/cvmfs/tomo.esrf.fr/software/packages/ubuntu24.04/x86_64/nightraildev/26_06_01/lib
-    python -m unittest hdf5plugin.test
-
 Run an explicit Kakadu roundtrip by adding Kakadu to ``LD_LIBRARY_PATH``::
 
-    export LD_LIBRARY_PATH=/data/scisofttmp/mirone/KD/lib:/cvmfs/tomo.esrf.fr/software/packages/ubuntu24.04/x86_64/nightraildev/26_06_01/lib
+    export LD_LIBRARY_PATH=/data/scisofttmp/mirone/KD/lib
 
     python - <<'PY'
     import os
@@ -180,6 +175,10 @@ Run an explicit Kakadu roundtrip by adding Kakadu to ``LD_LIBRARY_PATH``::
     finally:
         os.unlink(path)
     PY
+
+Run the normal hdf5plugin tests in the same Kakadu-enabled environment::
+
+    python -m unittest hdf5plugin.test
 
 To debug backend selection, enable dispatcher diagnostics::
 

--- a/README.rst
+++ b/README.rst
@@ -134,7 +134,48 @@ Check that the main HDF5 filter does not link any JPEG2000 backend directly::
 
 The output should not list OpenJPEG or ``libkdu_*``.  The optional Kakadu
 backend is separate and should show unresolved Kakadu libraries unless
-``LD_LIBRARY_PATH`` contains the Kakadu lib directory::
+``LD_LIBRARY_PATH`` contains the Kakadu lib directory.
+
+With the command sequence above, only the Kakadu backend is expected to be
+built on systems where OpenJPEG development files are not installed.  Seeing
+only this backend is therefore normal::
+
+    ls -l "$(python - <<'PY'
+    from pathlib import Path
+    import hdf5plugin
+    print(Path(hdf5plugin.__file__).resolve().parent / "backends" / "jpeg2000")
+    PY
+    )"
+
+The OpenJPEG backend is built only when pkg-config can find ``openjp2.pc`` at
+build time.  A system runtime library such as ``libopenjp2.so.7`` is not enough:
+the build also needs the OpenJPEG headers and pkg-config metadata.
+
+``PKG_CONFIG_PATH`` must point to the directory that contains ``openjp2.pc``,
+not to the file itself.  For example, if the file is::
+
+    /opt/openjpeg/lib/pkgconfig/openjp2.pc
+
+configure the environment as::
+
+    export PKG_CONFIG_PATH=/opt/openjpeg/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}
+    pkg-config --modversion openjp2
+    python -m pip install --no-build-isolation --force-reinstall .
+
+On systems where OpenJPEG was installed in another prefix, first find the
+metadata file and use its parent directory::
+
+    find /usr /opt /data/scisofttmp/mirone -name openjp2.pc 2>/dev/null
+    export PKG_CONFIG_PATH=/directory/containing/openjp2.pc${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}
+    pkg-config --cflags --libs openjp2
+
+After that, the backend directory should contain both optional backends when
+Kakadu is also available::
+
+    hdf5plugin/backends/jpeg2000/libh5jpeg2000_kakadu_backend.so
+    hdf5plugin/backends/jpeg2000/libh5jpeg2000_openjpeg_backend.so
+
+The Kakadu backend check is::
 
     KAKADU_BACKEND="$(python - <<'PY'
     from pathlib import Path

--- a/README.rst
+++ b/README.rst
@@ -88,18 +88,31 @@ manifest can be selected with::
 Kakadu test procedure used in this development environment
 ----------------------------------------------------------
 
-The following commands assume the same environment used during development:
+The following commands mirror the quickstart style used in ``blosc2_j2k``:
+they create a fresh working directory and a fresh virtual environment under
+``/tmp``.  The project sources are fetched from the ``alemirone`` GitHub
+repository.  The only local, non-packaged dependency is the Kakadu installation
+already present in ``/data/scisofttmp/mirone/KD``.
 
-* source tree: ``/data/scisofttmp/mirone/PROJECTS/segmentation/NR/hdf5plugin_thomas``
-* test virtual environment: ``/data/scisofttmp/mirone/environments/hdf5plugin_jpeg2000_test``
+* repository: ``https://github.com/alemirone/hdf5plugin_thomas.git``
+* branch: ``jpeg2000``
+* temporary workdir and virtual environment: under ``/tmp``
 * Kakadu installation already present in: ``/data/scisofttmp/mirone/KD``
-* OpenJPEG pkg-config from the NightRail development environment
+* OpenJPEG discovered through pkg-config from the NightRail development stack
 
-Copy-paste build and install::
+Copy-paste full source quickstart::
 
-    cd /data/scisofttmp/mirone/PROJECTS/segmentation/NR/hdf5plugin_thomas
+    workdir="$(mktemp -d -p /tmp hdf5plugin_jpeg2000_kakadu_XXXXXXXX)"
+    cd "$workdir"
+    echo "Using quickstart directory: $PWD"
 
-    source /data/scisofttmp/mirone/environments/hdf5plugin_jpeg2000_test/bin/activate
+    python3 -m venv .venv
+    source .venv/bin/activate
+    python -m pip install --upgrade pip setuptools wheel
+    python -m pip install py-cpuinfo pkgconfig packaging numpy h5py
+
+    git clone --branch jpeg2000 https://github.com/alemirone/hdf5plugin_thomas.git
+    cd hdf5plugin_thomas
 
     export PKG_CONFIG_PATH=/cvmfs/tomo.esrf.fr/software/packages/ubuntu24.04/x86_64/nightraildev/26_06_01/lib/pkgconfig
     export KDIR=/data/scisofttmp/mirone/KD
@@ -109,13 +122,27 @@ Copy-paste build and install::
 
 Check that the main HDF5 filter does not link Kakadu directly::
 
-    ldd /data/scisofttmp/mirone/environments/hdf5plugin_jpeg2000_test/lib/python3.12/site-packages/hdf5plugin/plugins/libh5jpeg2000.so
+    JPEG2000_FILTER="$(python - <<'PY'
+    from pathlib import Path
+    import hdf5plugin
+    print(Path(hdf5plugin.__file__).resolve().parent / "plugins" / "libh5jpeg2000.so")
+    PY
+    )"
+
+    ldd "$JPEG2000_FILTER"
 
 The output should list OpenJPEG but not ``libkdu_*``.  The optional backend is
 separate and should show unresolved Kakadu libraries unless ``LD_LIBRARY_PATH``
 contains the Kakadu lib directory::
 
-    ldd /data/scisofttmp/mirone/environments/hdf5plugin_jpeg2000_test/lib/python3.12/site-packages/hdf5plugin/backends/jpeg2000/libh5jpeg2000_kakadu_backend.so
+    KAKADU_BACKEND="$(python - <<'PY'
+    from pathlib import Path
+    import hdf5plugin
+    print(Path(hdf5plugin.__file__).resolve().parent / "backends" / "jpeg2000" / "libh5jpeg2000_kakadu_backend.so")
+    PY
+    )"
+
+    ldd "$KAKADU_BACKEND"
 
 Run the normal hdf5plugin tests without Kakadu in ``LD_LIBRARY_PATH``.  This
 checks that the package remains usable and falls back to OpenJPEG::

--- a/lib/H5Z-jpeg2000/H5Zjpeg2000.c
+++ b/lib/H5Z-jpeg2000/H5Zjpeg2000.c
@@ -184,8 +184,8 @@ static size_t filter_jpeg2000(unsigned int flags, size_t cd_nelmts,
   if (flags & H5Z_FLAG_REVERSE) { /** Decompress data **/
     /*
      * Enter the backend dispatcher.  This symbol is stable for the HDF5
-     * filter; runtime backend selection (manifest/env/fallback) happens
-     * inside h5z_jpeg2000_decompress().
+     * filter; runtime backend selection (explicit env var, manifest, or
+     * last-resort auto policy) happens inside h5z_jpeg2000_decompress().
      */
     result = h5z_jpeg2000_decompress(nbytes, input_buffer, &output_size, &output_buffer);
     if (result < 0) {
@@ -198,9 +198,10 @@ static size_t filter_jpeg2000(unsigned int flags, size_t cd_nelmts,
 
   } else { /** Compress data **/
     /*
-     * Same indirection for encoding: H5Zjpeg2000.c no longer calls OpenJPEG
-     * directly.  h5z_jpeg2000_compress() dispatches to the configured backend
-     * while keeping the HDF5 filter entry point independent from backend choice.
+     * Same indirection for encoding: H5Zjpeg2000.c no longer calls OpenJPEG or
+     * Kakadu directly.  h5z_jpeg2000_compress() dispatches to the configured
+     * backend while keeping the HDF5 filter entry point independent from
+     * backend choice and backend library availability.
      */
     result = h5z_jpeg2000_compress(nbytes, input_buffer, cd_values[CD_INDEX_WIDTH],
                       cd_values[CD_INDEX_HEIGHT], cd_values[CD_INDEX_NCOMPS],

--- a/lib/H5Z-jpeg2000/H5Zjpeg2000.c
+++ b/lib/H5Z-jpeg2000/H5Zjpeg2000.c
@@ -182,7 +182,12 @@ static size_t filter_jpeg2000(unsigned int flags, size_t cd_nelmts,
   void *input_buffer = *buf;
 
   if (flags & H5Z_FLAG_REVERSE) { /** Decompress data **/
-    result = decompress(nbytes, input_buffer, &output_size, &output_buffer);
+    /*
+     * Enter the backend dispatcher.  This symbol is stable for the HDF5
+     * filter; runtime backend selection (manifest/env/fallback) happens
+     * inside h5z_jpeg2000_decompress().
+     */
+    result = h5z_jpeg2000_decompress(nbytes, input_buffer, &output_size, &output_buffer);
     if (result < 0) {
       fprintf(stderr, "decompress failed\n");
       if (output_buffer) {
@@ -192,7 +197,12 @@ static size_t filter_jpeg2000(unsigned int flags, size_t cd_nelmts,
     }
 
   } else { /** Compress data **/
-    result = compress(nbytes, input_buffer, cd_values[CD_INDEX_WIDTH],
+    /*
+     * Same indirection for encoding: H5Zjpeg2000.c no longer calls OpenJPEG
+     * directly.  h5z_jpeg2000_compress() dispatches to the configured backend
+     * while keeping the HDF5 filter entry point independent from backend choice.
+     */
+    result = h5z_jpeg2000_compress(nbytes, input_buffer, cd_values[CD_INDEX_WIDTH],
                       cd_values[CD_INDEX_HEIGHT], cd_values[CD_INDEX_NCOMPS],
                       cd_values[CD_INDEX_DTYPE],
                       cd_values[CD_INDEX_RATIO] /

--- a/lib/H5Z-jpeg2000/H5Zjpeg2000_backend.h
+++ b/lib/H5Z-jpeg2000/H5Zjpeg2000_backend.h
@@ -30,10 +30,10 @@ typedef enum {
 } h5z_j2k_dtype_t;
 
 /*
- * Backend ABI for the standalone J2K filter.  OpenJPEG remains built into
- * the HDF5 filter itself, while optional commercial/open-source backends can
- * live in separate shared libraries.  This keeps the HDF5 filter loadable even
- * when optional backend dependencies such as Kakadu are not on LD_LIBRARY_PATH.
+ * Backend ABI for the standalone J2K filter.  The HDF5 filter itself stays
+ * backend-neutral; OpenJPEG, Kakadu and future engines live in separate shared
+ * libraries loaded by the dispatcher.  This keeps the HDF5 filter loadable even
+ * when optional backend dependencies are not on LD_LIBRARY_PATH.
  *
  * HTJ2K is intentionally planned as a separate HDF5 plugin rather
  * than another mode of this J2K filter.  That future plugin can use

--- a/lib/H5Z-jpeg2000/H5Zjpeg2000_backend.h
+++ b/lib/H5Z-jpeg2000/H5Zjpeg2000_backend.h
@@ -1,4 +1,19 @@
+#ifndef H5Z_JPEG2000_BACKEND_H
+#define H5Z_JPEG2000_BACKEND_H
+
 #include <sys/types.h>
+
+#define H5Z_JPEG2000_BACKEND_ENV "HDF5PLUGIN_JPEG2000_BACKEND"
+#define H5Z_JPEG2000_MANIFEST_ENV "HDF5PLUGIN_JPEG2000_MANIFEST"
+#define H5Z_JPEG2000_MANIFEST_NAME "hdf5plugin_jpeg2000_plugins.json"
+
+/* Backend selection is process-local and never stored in HDF5 chunks. */
+
+/*
+ * Keep backend entry points prefixed. Plain names such as compress() or
+ * decompress() are too generic for HDF5 plugins loaded into a shared
+ * process namespace, and become ambiguous once multiple backends exist.
+ */
 
 typedef enum {
   H5Z_J2K_DTYPE_BITFIELD = 0,
@@ -10,8 +25,31 @@ typedef enum {
   H5Z_J2K_DTYPE_UINT32 = 6,
 } h5z_j2k_dtype_t;
 
+/*
+ * Backend ABI for the standalone J2K filter.  OpenJPEG is the only
+ * backend wired today, but this indirection is meant to let us add
+ * alternatives such as Kakadu or Grok without changing the HDF5
+ * filter entry point or the file format.
+ *
+ * HTJ2K is intentionally planned as a separate HDF5 plugin rather
+ * than another mode of this J2K filter.  That future plugin can use
+ * the same pattern with an HTJ2K-specific backend list, e.g.
+ * OpenHTJ2K, Kakadu, or Grok where supported.
+ */
+typedef struct {
+  const char *name;
+  int (*available)(void);
+  int (*compress)(size_t input_nbytes, void *input_buffer, unsigned int width,
+                  unsigned int height, unsigned int ncomps, unsigned int dtype,
+                  float compression_ratio, size_t *output_nbytes,
+                  void **output_buffer);
+  int (*decompress)(size_t compressed_nbytes, void *compressed_buffer,
+                    size_t *output_nbytes, void **output_buffer);
+} h5z_jpeg2000_backend_t;
+
 /**
- * compress() – encode a raw pixel buffer to a J2K codestream in memory.
+ * Encode a raw pixel buffer to a J2K codestream in memory using the selected
+ * backend.
  *
  * @param input_nbytes       byte length of the input pixel buffer
  * @param input_buffer       pointer to the input pixel buffer (interleaved
@@ -26,13 +64,14 @@ typedef enum {
  * @param output_buffer      [out] caller-owned output buffer (free() when done)
  * @return 0 on success, -1 on failure
  */
-int compress(size_t compressed_nbytes, void *compressed_buffer,
-             unsigned int width, unsigned int height, unsigned int ncomps,
-             unsigned int dtype, float compression_ratio, size_t *output_nbytes,
-             void **output_buffer);
+int h5z_jpeg2000_compress(size_t input_nbytes, void *input_buffer,
+                          unsigned int width, unsigned int height,
+                          unsigned int ncomps, unsigned int dtype,
+                          float compression_ratio, size_t *output_nbytes,
+                          void **output_buffer);
 
 /**
- * decompress() – decode a raw J2K / HTJ2K codestream from memory.
+ * Decode a raw J2K codestream from memory using the selected backend.
  *
  * @param compressed_nbytes  byte length of the input codestream
  * @param compressed_buffer  pointer to the input codestream
@@ -40,5 +79,20 @@ int compress(size_t compressed_nbytes, void *compressed_buffer,
  * @param output_buffer      [out] caller-owned output buffer (free() when done)
  * @return 0 on success, -1 on failure
  */
-int decompress(size_t compressed_nbytes, void *compressed_buffer,
-               size_t *output_nbytes, void **output_buffer);
+int h5z_jpeg2000_decompress(size_t compressed_nbytes, void *compressed_buffer,
+                            size_t *output_nbytes, void **output_buffer);
+
+const h5z_jpeg2000_backend_t *h5z_jpeg2000_select_backend(void);
+
+int h5z_jpeg2000_openjpeg_compress(
+    size_t input_nbytes, void *input_buffer, unsigned int width,
+    unsigned int height, unsigned int ncomps, unsigned int dtype,
+    float compression_ratio, size_t *output_nbytes, void **output_buffer);
+int h5z_jpeg2000_openjpeg_decompress(size_t compressed_nbytes,
+                                     void *compressed_buffer,
+                                     size_t *output_nbytes,
+                                     void **output_buffer);
+
+extern const h5z_jpeg2000_backend_t h5z_jpeg2000_openjpeg_backend;
+
+#endif

--- a/lib/H5Z-jpeg2000/H5Zjpeg2000_backend.h
+++ b/lib/H5Z-jpeg2000/H5Zjpeg2000_backend.h
@@ -3,6 +3,10 @@
 
 #include <sys/types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define H5Z_JPEG2000_BACKEND_ENV "HDF5PLUGIN_JPEG2000_BACKEND"
 #define H5Z_JPEG2000_MANIFEST_ENV "HDF5PLUGIN_JPEG2000_MANIFEST"
 #define H5Z_JPEG2000_MANIFEST_NAME "hdf5plugin_jpeg2000_plugins.json"
@@ -26,10 +30,10 @@ typedef enum {
 } h5z_j2k_dtype_t;
 
 /*
- * Backend ABI for the standalone J2K filter.  OpenJPEG is the only
- * backend wired today, but this indirection is meant to let us add
- * alternatives such as Kakadu or Grok without changing the HDF5
- * filter entry point or the file format.
+ * Backend ABI for the standalone J2K filter.  OpenJPEG remains built into
+ * the HDF5 filter itself, while optional commercial/open-source backends can
+ * live in separate shared libraries.  This keeps the HDF5 filter loadable even
+ * when optional backend dependencies such as Kakadu are not on LD_LIBRARY_PATH.
  *
  * HTJ2K is intentionally planned as a separate HDF5 plugin rather
  * than another mode of this J2K filter.  That future plugin can use
@@ -94,5 +98,22 @@ int h5z_jpeg2000_openjpeg_decompress(size_t compressed_nbytes,
                                      void **output_buffer);
 
 extern const h5z_jpeg2000_backend_t h5z_jpeg2000_openjpeg_backend;
+
+#ifdef H5Z_JPEG2000_HAVE_KAKADU
+int h5z_jpeg2000_kakadu_compress(
+    size_t input_nbytes, void *input_buffer, unsigned int width,
+    unsigned int height, unsigned int ncomps, unsigned int dtype,
+    float compression_ratio, size_t *output_nbytes, void **output_buffer);
+int h5z_jpeg2000_kakadu_decompress(size_t compressed_nbytes,
+                                   void *compressed_buffer,
+                                   size_t *output_nbytes,
+                                   void **output_buffer);
+
+extern const h5z_jpeg2000_backend_t h5z_jpeg2000_kakadu_backend;
+#endif
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/H5Z-jpeg2000/backends/kakadu.cpp
+++ b/lib/H5Z-jpeg2000/backends/kakadu.cpp
@@ -1,0 +1,683 @@
+#include "H5Zjpeg2000_backend.h"
+
+#ifdef H5Z_JPEG2000_HAVE_KAKADU
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "jp2.h"
+#include "kdu_compressed.h"
+#include "kdu_messaging.h"
+#include "kdu_params.h"
+#include "kdu_stripe_compressor.h"
+#include "kdu_stripe_decompressor.h"
+#include "kdu_threads.h"
+#include "kdu_utils.h"
+
+using namespace kdu_core;
+using namespace kdu_supp;
+
+namespace {
+
+class KduErrorHandler : public kdu_message {
+public:
+  explicit KduErrorHandler(bool debug_enabled) : debug(debug_enabled) {}
+
+  void put_text(const char *string) override {
+    if (string) {
+      buffer.append(string);
+    }
+  }
+
+  void flush(bool end_of_message) override {
+    if (end_of_message) {
+      if (debug) {
+        fprintf(stderr, "[hdf5plugin/jpeg2000] Kakadu error: %s\n", buffer.c_str());
+      }
+      buffer.clear();
+      throw KDU_ERROR_EXCEPTION;
+    }
+  }
+
+private:
+  bool debug = false;
+  std::string buffer;
+};
+
+class KduWarningHandler : public kdu_message {
+public:
+  explicit KduWarningHandler(bool debug_enabled) : debug(debug_enabled) {}
+
+  void put_text(const char *string) override {
+    if (string) {
+      buffer.append(string);
+    }
+  }
+
+  void flush(bool end_of_message) override {
+    if (end_of_message) {
+      if (debug) {
+        fprintf(stderr, "[hdf5plugin/jpeg2000] Kakadu warning: %s\n", buffer.c_str());
+      }
+      buffer.clear();
+    }
+  }
+
+private:
+  bool debug = false;
+  std::string buffer;
+};
+
+bool debug_enabled() { return std::getenv("HDF5PLUGIN_JPEG2000_DEBUG") != nullptr; }
+
+void ensure_kakadu_handlers(bool debug) {
+  static bool configured = false;
+  if (configured) {
+    return;
+  }
+  configured = true;
+  static KduErrorHandler err_handler(debug);
+  static KduWarningHandler warn_handler(debug);
+  kdu_customize_errors(&err_handler);
+  kdu_customize_warnings(&warn_handler);
+}
+
+bool env_flag(const char *name, bool default_value) {
+  const char *v = std::getenv(name);
+  if (v == nullptr || *v == '\0') {
+    return default_value;
+  }
+  auto equals_ci = [](const char *a, const char *b) {
+    while (*a != '\0' && *b != '\0') {
+      if (std::tolower(static_cast<unsigned char>(*a)) !=
+          std::tolower(static_cast<unsigned char>(*b))) {
+        return false;
+      }
+      ++a;
+      ++b;
+    }
+    return *a == '\0' && *b == '\0';
+  };
+  if (equals_ci(v, "1") || equals_ci(v, "true") || equals_ci(v, "yes") ||
+      equals_ci(v, "on")) {
+    return true;
+  }
+  if (equals_ci(v, "0") || equals_ci(v, "false") || equals_ci(v, "no") ||
+      equals_ci(v, "off")) {
+    return false;
+  }
+  return default_value;
+}
+
+int env_int(const char *name, int default_value) {
+  const char *v = std::getenv(name);
+  if (v == nullptr || *v == '\0') {
+    return default_value;
+  }
+  char *end = nullptr;
+  long n = std::strtol(v, &end, 10);
+  if (end == v || (end && *end != '\0')) {
+    return default_value;
+  }
+  if (n < 0) {
+    n = 0;
+  } else if (n > 1024) {
+    n = 1024;
+  }
+  return static_cast<int>(n);
+}
+
+struct KakaduTune {
+  bool force_precise = true;
+  bool want_fastest = false;
+  int threads = 0;
+};
+
+KakaduTune get_kakadu_tune() {
+  KakaduTune t;
+  t.force_precise = env_flag("HDF5PLUGIN_JPEG2000_KAKADU_PRECISE", true);
+  t.want_fastest = env_flag("HDF5PLUGIN_JPEG2000_KAKADU_FAST", false);
+  t.threads = env_int("HDF5PLUGIN_JPEG2000_KAKADU_THREADS", 0);
+  return t;
+}
+
+class ThreadEnvGuard {
+public:
+  ThreadEnvGuard() = default;
+  ThreadEnvGuard(const ThreadEnvGuard &) = delete;
+  ThreadEnvGuard &operator=(const ThreadEnvGuard &) = delete;
+
+  void setup(int threads) {
+    if (threads <= 1) {
+      return;
+    }
+    env.create();
+    for (int i = 1; i < threads; ++i) {
+      env.add_thread();
+    }
+    created = true;
+  }
+
+  kdu_thread_env *ptr() { return created ? &env : nullptr; }
+
+  ~ThreadEnvGuard() {
+    if (created) {
+      (void)env.destroy();
+    }
+  }
+
+private:
+  bool created = false;
+  kdu_thread_env env;
+};
+
+class MemTarget : public kdu_compressed_target_nonnative {
+public:
+  std::vector<kdu_byte> data;
+
+  bool post_write(int num_bytes) override {
+    size_t offset = data.size();
+    data.resize(offset + static_cast<size_t>(num_bytes));
+    pull_data(reinterpret_cast<kdu_byte *>(data.data()), static_cast<int>(offset), num_bytes);
+    return true;
+  }
+};
+
+struct DtypeInfo {
+  int precision;
+  bool is_signed;
+  int size;
+};
+
+bool set_dtype_info(DtypeInfo &info, int precision, bool is_signed, int size) {
+  info.precision = precision;
+  info.is_signed = is_signed;
+  info.size = size;
+  return true;
+}
+
+bool dtype_info(unsigned int dtype, DtypeInfo &info) {
+  switch (static_cast<h5z_j2k_dtype_t>(dtype)) {
+  case H5Z_J2K_DTYPE_INT8:
+    return set_dtype_info(info, 8, true, 1);
+  case H5Z_J2K_DTYPE_UINT8:
+    return set_dtype_info(info, 8, false, 1);
+  case H5Z_J2K_DTYPE_INT16:
+    return set_dtype_info(info, 16, true, 2);
+  case H5Z_J2K_DTYPE_UINT16:
+    return set_dtype_info(info, 16, false, 2);
+  case H5Z_J2K_DTYPE_INT32:
+    return set_dtype_info(info, 32, true, 4);
+  case H5Z_J2K_DTYPE_UINT32:
+    return set_dtype_info(info, 32, false, 4);
+  default:
+    return false;
+  }
+}
+
+bool set_siz_params(siz_params &siz, int width, int height, int num_comps,
+                    const DtypeInfo &dtype) {
+  if (width <= 0 || height <= 0 || !(num_comps == 1 || num_comps == 3)) {
+    return false;
+  }
+  siz.set(Scomponents, 0, 0, num_comps);
+  siz.set(Ssize, 0, 0, height);
+  siz.set(Ssize, 0, 1, width);
+  siz.set(Sorigin, 0, 0, 0);
+  siz.set(Sorigin, 0, 1, 0);
+  siz.set(Stiles, 0, 0, height);
+  siz.set(Stiles, 0, 1, width);
+  siz.set(Stile_origin, 0, 0, 0);
+  siz.set(Stile_origin, 0, 1, 0);
+
+  for (int c = 0; c < num_comps; ++c) {
+    siz.set(Sdims, c, 0, height);
+    siz.set(Sdims, c, 1, width);
+    siz.set(Sprecision, c, 0, dtype.precision);
+    siz.set(Ssigned, c, 0, dtype.is_signed);
+  }
+  return true;
+}
+
+bool kakadu_extra_has_param(const char *param) {
+  const char *extra = std::getenv("HDF5PLUGIN_JPEG2000_KAKADU_PARAMS");
+  if (extra == nullptr || *extra == '\0' || param == nullptr || *param == '\0') {
+    return false;
+  }
+  std::string s(extra);
+  std::string p(param);
+  for (char &ch : s) {
+    ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+  }
+  for (char &ch : p) {
+    ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+  }
+  return s.find(p) != std::string::npos;
+}
+
+void apply_kakadu_mode(siz_params &siz) {
+  siz.parse_string("Sncap=P15");
+  siz.parse_string("Cmodes=0");
+}
+
+void apply_kakadu_rate_defaults(siz_params &siz, int precision, bool rate_controlled) {
+  if (!rate_controlled) {
+    if (!kakadu_extra_has_param("creversible")) {
+      siz.parse_string("Creversible=yes");
+    }
+    return;
+  }
+  if (!kakadu_extra_has_param("creversible")) {
+    siz.parse_string("Creversible=no");
+  }
+  if (!kakadu_extra_has_param("qstep") && !kakadu_extra_has_param("qfactor")) {
+    const double nominal_qstep = std::ldexp(1.0, -(precision + 5));
+    const double grok_readable_floor = std::ldexp(1.0, -18);
+    const double qstep = std::max(nominal_qstep, grok_readable_floor);
+    char cmd[64];
+    std::snprintf(cmd, sizeof(cmd), "Qstep=%.17g", qstep);
+    siz.parse_string(cmd);
+  }
+}
+
+void apply_kakadu_precision_defaults(siz_params &siz, int precision) {
+  const char *clevels_s = std::getenv("HDF5PLUGIN_JPEG2000_CLEVELS");
+  if (precision == 32 && (clevels_s == nullptr || *clevels_s == '\0') &&
+      !kakadu_extra_has_param("clevels")) {
+    siz.parse_string("Clevels=3");
+  }
+}
+
+void apply_kakadu_overrides(siz_params &siz) {
+  const char *extra = std::getenv("HDF5PLUGIN_JPEG2000_KAKADU_PARAMS");
+  if (extra != nullptr && *extra != '\0') {
+    std::string s(extra);
+    size_t start = 0;
+    while (start < s.size()) {
+      size_t end = s.find_first_of(";\n", start);
+      if (end == std::string::npos) {
+        end = s.size();
+      }
+      std::string tok = s.substr(start, end - start);
+      size_t l = tok.find_first_not_of(" \t\r");
+      size_t r = tok.find_last_not_of(" \t\r");
+      if (l != std::string::npos && r != std::string::npos) {
+        tok = tok.substr(l, r - l + 1);
+      } else {
+        tok.clear();
+      }
+      if (!tok.empty()) {
+        siz.parse_string(tok.c_str());
+      }
+      start = end + 1;
+    }
+  }
+
+  const char *clevels_s = std::getenv("HDF5PLUGIN_JPEG2000_CLEVELS");
+  if (clevels_s != nullptr && *clevels_s != '\0') {
+    char *end = nullptr;
+    long clevels = std::strtol(clevels_s, &end, 10);
+    if (end != clevels_s && end && *end == '\0') {
+      if (clevels < 0) {
+        clevels = 0;
+      } else if (clevels > 32) {
+        clevels = 32;
+      }
+      std::string cmd = "Clevels=" + std::to_string(clevels);
+      siz.parse_string(cmd.c_str());
+    }
+  }
+}
+
+bool has_jp2_signature(const uint8_t *data, size_t len) {
+  if (data == nullptr || len < 12) {
+    return false;
+  }
+  static const uint8_t sig[12] = {
+      0x00, 0x00, 0x00, 0x0c, 0x6a, 0x50, 0x20, 0x20, 0x0d, 0x0a, 0x87, 0x0a};
+  return std::memcmp(data, sig, sizeof(sig)) == 0;
+}
+
+int kakadu_available() { return 1; }
+
+} // namespace
+
+extern "C" int h5z_jpeg2000_kakadu_compress(
+    size_t input_nbytes, void *input_buffer, unsigned int width,
+    unsigned int height, unsigned int ncomps, unsigned int dtype,
+    float compression_ratio, size_t *output_nbytes, void **output_buffer) {
+  if (!input_buffer || !output_nbytes || !output_buffer) {
+    return -1;
+  }
+  *output_nbytes = 0;
+  *output_buffer = nullptr;
+
+  const bool debug = debug_enabled();
+  ensure_kakadu_handlers(debug);
+  const KakaduTune tune = get_kakadu_tune();
+
+  DtypeInfo di;
+  if (!dtype_info(dtype, di)) {
+    return -1;
+  }
+  if (!(ncomps == 1 || ncomps == 3)) {
+    return -1;
+  }
+  const size_t expected = static_cast<size_t>(width) * height * ncomps * di.size;
+  if (expected != input_nbytes) {
+    return -1;
+  }
+
+  siz_params siz;
+  if (!set_siz_params(siz, static_cast<int>(width), static_cast<int>(height),
+                      static_cast<int>(ncomps), di)) {
+    return -1;
+  }
+
+  MemTarget target;
+  kdu_codestream codestream;
+  try {
+    std::unique_ptr<cod_params> cod_holder;
+    if (siz.access_cluster(COD_params) == nullptr) {
+      cod_holder.reset(new cod_params());
+      cod_holder->link(&siz, -1, -1, 0, 0);
+    }
+    apply_kakadu_mode(siz);
+    siz.finalize_all();
+    codestream.create(&siz, &target);
+
+    const bool rate_controlled = compression_ratio > 1.0f;
+    apply_kakadu_rate_defaults(*codestream.access_siz(), di.precision, rate_controlled);
+    apply_kakadu_precision_defaults(*codestream.access_siz(), di.precision);
+    apply_kakadu_overrides(*codestream.access_siz());
+    codestream.access_siz()->finalize_all();
+
+    kdu_stripe_compressor compressor;
+    ThreadEnvGuard thread_env;
+    thread_env.setup(tune.threads);
+    kdu_thread_env *env_ptr = thread_env.ptr();
+    if (rate_controlled) {
+      kdu_long layer_size = static_cast<kdu_long>(
+          static_cast<double>(input_nbytes) / static_cast<double>(compression_ratio));
+      compressor.start(codestream, 1, &layer_size, nullptr, 0, false,
+                       tune.force_precise, true, 0.0, 0, tune.want_fastest, env_ptr);
+    } else {
+      compressor.start(codestream, 0, nullptr, nullptr, 0, false,
+                       tune.force_precise, true, 0.0, 0, tune.want_fastest, env_ptr);
+    }
+
+    std::vector<int> stripe_heights(ncomps, static_cast<int>(height));
+    std::vector<int> sample_gaps(ncomps, static_cast<int>(ncomps));
+    std::vector<int> row_gaps(ncomps, static_cast<int>(width * ncomps));
+    std::vector<int> precisions(ncomps, di.precision);
+    std::unique_ptr<bool[]> is_signed(new bool[ncomps]);
+    for (unsigned int c = 0; c < ncomps; ++c) {
+      is_signed[c] = di.is_signed;
+    }
+
+    bool needs_more = false;
+    if (di.size == 1 && !di.is_signed) {
+      std::vector<kdu_byte *> stripe_bufs(ncomps);
+      for (unsigned int c = 0; c < ncomps; ++c) {
+        stripe_bufs[c] = reinterpret_cast<kdu_byte *>(input_buffer) + c;
+      }
+      needs_more = compressor.push_stripe(stripe_bufs.data(), stripe_heights.data(),
+                                          sample_gaps.data(), row_gaps.data(),
+                                          precisions.data());
+    } else if (di.size == 1 && di.is_signed) {
+      const int8_t *input = reinterpret_cast<const int8_t *>(input_buffer);
+      std::vector<kdu_int16> tmp(static_cast<size_t>(width) * height * ncomps);
+      for (size_t i = 0; i < tmp.size(); ++i) {
+        tmp[i] = static_cast<kdu_int16>(input[i]);
+      }
+      needs_more = compressor.push_stripe(tmp.data(), stripe_heights.data(), nullptr,
+                                          nullptr, nullptr, precisions.data(),
+                                          is_signed.get());
+    } else if (di.size == 2) {
+      needs_more = compressor.push_stripe(reinterpret_cast<kdu_int16 *>(input_buffer),
+                                          stripe_heights.data(), nullptr, nullptr,
+                                          nullptr, precisions.data(), is_signed.get());
+    } else if (di.size == 4 && di.is_signed) {
+      needs_more = compressor.push_stripe(reinterpret_cast<kdu_int32 *>(input_buffer),
+                                          stripe_heights.data(), nullptr, nullptr,
+                                          nullptr, precisions.data(), is_signed.get());
+    } else if (di.size == 4) {
+      const uint32_t *input32 = reinterpret_cast<const uint32_t *>(input_buffer);
+      std::vector<kdu_int32> tmp(static_cast<size_t>(width) * height * ncomps);
+      constexpr int64_t kBias32 = int64_t{1} << 31;
+      for (size_t i = 0; i < tmp.size(); ++i) {
+        tmp[i] = static_cast<kdu_int32>(static_cast<int64_t>(input32[i]) - kBias32);
+      }
+      needs_more = compressor.push_stripe(tmp.data(), stripe_heights.data(), nullptr,
+                                          nullptr, nullptr, precisions.data(),
+                                          is_signed.get());
+    }
+    (void)needs_more;
+
+    compressor.finish();
+    codestream.destroy();
+  } catch (kdu_exception) {
+    if (debug) {
+      fprintf(stderr, "[hdf5plugin/jpeg2000] Kakadu encoder exception\n");
+    }
+    return -1;
+  }
+
+  void *out = std::malloc(target.data.size());
+  if (out == nullptr) {
+    return -1;
+  }
+  std::memcpy(out, target.data.data(), target.data.size());
+  *output_buffer = out;
+  *output_nbytes = target.data.size();
+  return 0;
+}
+
+extern "C" int h5z_jpeg2000_kakadu_decompress(size_t compressed_nbytes,
+                                               void *compressed_buffer,
+                                               size_t *output_nbytes,
+                                               void **output_buffer) {
+  if (!compressed_buffer || compressed_nbytes == 0 || !output_nbytes || !output_buffer) {
+    return -1;
+  }
+  *output_nbytes = 0;
+  *output_buffer = nullptr;
+
+  const bool debug = debug_enabled();
+  ensure_kakadu_handlers(debug);
+  const KakaduTune tune = get_kakadu_tune();
+
+  kdu_compressed_source_buffered source;
+  source.open(reinterpret_cast<kdu_byte *>(compressed_buffer), compressed_nbytes);
+
+  kdu_codestream codestream;
+  jp2_family_src family;
+  jp2_source jp2;
+
+  try {
+    const bool is_jp2 = has_jp2_signature(reinterpret_cast<const uint8_t *>(compressed_buffer),
+                                          compressed_nbytes);
+    if (is_jp2) {
+      family.open(&source);
+      jp2.open(&family);
+      int hdr = jp2.read_header(true);
+      if (hdr <= 0) {
+        return -1;
+      }
+      codestream.create(&jp2);
+    } else {
+      codestream.create(&source);
+    }
+
+    int num_comps = codestream.get_num_components(true);
+    if (!(num_comps == 1 || num_comps == 3)) {
+      codestream.destroy();
+      return -1;
+    }
+
+    kdu_dims dims;
+    codestream.get_dims(0, dims, true);
+    int width = dims.size.x;
+    int height = dims.size.y;
+    for (int c = 1; c < num_comps; ++c) {
+      kdu_dims cdims;
+      codestream.get_dims(c, cdims, true);
+      if (cdims.size.x != width || cdims.size.y != height) {
+        codestream.destroy();
+        return -1;
+      }
+    }
+
+    int precision = codestream.get_bit_depth(0, true);
+    bool is_signed = codestream.get_signed(0, true);
+    for (int c = 1; c < num_comps; ++c) {
+      if (codestream.get_bit_depth(c, true) != precision ||
+          codestream.get_signed(c, true) != is_signed) {
+        codestream.destroy();
+        return -1;
+      }
+    }
+    if (!(precision == 8 || precision == 16 || precision == 32)) {
+      codestream.destroy();
+      return -1;
+    }
+
+    int typesize = (precision <= 8) ? 1 : ((precision <= 16) ? 2 : 4);
+    size_t expected = static_cast<size_t>(width) * height * num_comps * typesize;
+    void *out = std::malloc(expected);
+    if (out == nullptr) {
+      codestream.destroy();
+      return -1;
+    }
+
+    static thread_local kdu_stripe_decompressor *tls_decompressor =
+        new kdu_stripe_decompressor();
+    kdu_stripe_decompressor &decompressor = *tls_decompressor;
+    ThreadEnvGuard thread_env;
+    thread_env.setup(tune.threads);
+    decompressor.start(codestream, tune.force_precise, tune.want_fastest, thread_env.ptr());
+
+    std::vector<int> stripe_heights(num_comps, 0);
+    std::vector<int> precisions(num_comps, precision);
+    std::unique_ptr<bool[]> is_signed_flags(new bool[num_comps]);
+    for (int c = 0; c < num_comps; ++c) {
+      is_signed_flags[c] = is_signed;
+    }
+
+    int requested_stripe_height = env_int("HDF5PLUGIN_JPEG2000_KAKADU_DECODE_STRIPE_HEIGHT", 128);
+    int max_stripe_height =
+        (requested_stripe_height > 0 && requested_stripe_height < height) ? requested_stripe_height : height;
+    int rows_done = 0;
+    bool needs_more = true;
+
+    std::vector<kdu_int16> signed8;
+    std::vector<kdu_uint16> decoded16;
+    std::vector<kdu_int32> decoded32;
+    if (typesize == 1 && is_signed) {
+      signed8.resize(static_cast<size_t>(width) * height * num_comps);
+    } else if (typesize == 2 && !is_signed) {
+      decoded16.resize(expected / typesize);
+    } else if (typesize == 4) {
+      decoded32.resize(expected / typesize);
+    }
+
+    while (rows_done < height) {
+      int rows = height - rows_done;
+      if (rows > max_stripe_height) {
+        rows = max_stripe_height;
+      }
+      for (int c = 0; c < num_comps; ++c) {
+        stripe_heights[c] = rows;
+      }
+
+      size_t row_offset = static_cast<size_t>(rows_done) * width * num_comps;
+      if (typesize == 1 && !is_signed) {
+        uint8_t *stripe_output = reinterpret_cast<uint8_t *>(out) + row_offset;
+        needs_more = decompressor.pull_stripe(stripe_output, stripe_heights.data(),
+                                              nullptr, nullptr, nullptr,
+                                              precisions.data());
+      } else if (typesize == 1) {
+        kdu_int16 *stripe_output = signed8.data() + row_offset;
+        needs_more = decompressor.pull_stripe(stripe_output, stripe_heights.data(),
+                                              nullptr, nullptr, nullptr,
+                                              precisions.data(), is_signed_flags.get());
+      } else if (typesize == 2 && is_signed) {
+        kdu_int16 *stripe_output = reinterpret_cast<kdu_int16 *>(out) + row_offset;
+        needs_more = decompressor.pull_stripe(stripe_output, stripe_heights.data(),
+                                              nullptr, nullptr, nullptr,
+                                              precisions.data(), is_signed_flags.get());
+      } else if (typesize == 2) {
+        kdu_int16 *stripe_output = reinterpret_cast<kdu_int16 *>(decoded16.data()) + row_offset;
+        needs_more = decompressor.pull_stripe(stripe_output, stripe_heights.data(),
+                                              nullptr, nullptr, nullptr,
+                                              precisions.data(), is_signed_flags.get());
+      } else {
+        kdu_int32 *stripe_output = decoded32.data() + row_offset;
+        needs_more = decompressor.pull_stripe(stripe_output, stripe_heights.data(),
+                                              nullptr, nullptr, nullptr,
+                                              precisions.data(), is_signed_flags.get());
+      }
+      rows_done += rows;
+      if (!needs_more) {
+        break;
+      }
+    }
+
+    if (rows_done != height) {
+      std::free(out);
+      decompressor.reset();
+      codestream.destroy();
+      return -1;
+    }
+    decompressor.reset();
+
+    if (typesize == 1 && is_signed) {
+      int8_t *dst = reinterpret_cast<int8_t *>(out);
+      for (size_t i = 0; i < signed8.size(); ++i) {
+        dst[i] = static_cast<int8_t>(signed8[i]);
+      }
+    } else if (typesize == 2 && !is_signed) {
+      std::memcpy(out, decoded16.data(), expected);
+    } else if (typesize == 4 && is_signed) {
+      std::memcpy(out, decoded32.data(), expected);
+    } else if (typesize == 4) {
+      uint32_t *dst = reinterpret_cast<uint32_t *>(out);
+      constexpr int64_t kBias32 = int64_t{1} << 31;
+      for (size_t i = 0; i < decoded32.size(); ++i) {
+        dst[i] = static_cast<uint32_t>(static_cast<int64_t>(decoded32[i]) + kBias32);
+      }
+    }
+
+    codestream.destroy();
+    if (is_jp2) {
+      jp2.close();
+      family.close();
+    }
+
+    *output_buffer = out;
+    *output_nbytes = expected;
+    return 0;
+  } catch (kdu_exception) {
+    if (debug) {
+      fprintf(stderr, "[hdf5plugin/jpeg2000] Kakadu decoder exception\n");
+    }
+    return -1;
+  }
+}
+
+extern "C" const h5z_jpeg2000_backend_t h5z_jpeg2000_kakadu_backend = {
+    "kakadu",
+    kakadu_available,
+    h5z_jpeg2000_kakadu_compress,
+    h5z_jpeg2000_kakadu_decompress,
+};
+
+#endif

--- a/lib/H5Z-jpeg2000/backends/openjpeg.c
+++ b/lib/H5Z-jpeg2000/backends/openjpeg.c
@@ -1,0 +1,10 @@
+#include "H5Zjpeg2000_backend.h"
+
+static int openjpeg_available(void) { return 1; }
+
+const h5z_jpeg2000_backend_t h5z_jpeg2000_openjpeg_backend = {
+    "openjpeg",
+    openjpeg_available,
+    h5z_jpeg2000_openjpeg_compress,
+    h5z_jpeg2000_openjpeg_decompress,
+};

--- a/lib/H5Z-jpeg2000/backends/registry.c
+++ b/lib/H5Z-jpeg2000/backends/registry.c
@@ -18,7 +18,6 @@
 #define MAX_BACKEND_NAME_LEN 64
 
 static const h5z_jpeg2000_backend_t *const builtin_backends[] = {
-    &h5z_jpeg2000_openjpeg_backend,
     NULL,
 };
 
@@ -35,7 +34,7 @@ static int jpeg2000_debug_enabled(void) {
 }
 
 #ifndef _WIN32
-static void make_backend_path(char *out, size_t out_size) {
+static void make_backend_path(char *out, size_t out_size, const char *soname) {
   Dl_info info;
   out[0] = '\0';
   if (dladdr((void *)&h5z_jpeg2000_select_backend, &info) == 0 ||
@@ -50,24 +49,56 @@ static void make_backend_path(char *out, size_t out_size) {
     return;
   }
   *slash = '\0';
-  snprintf(out, out_size, "%s/../backends/jpeg2000/libh5jpeg2000_kakadu_backend.so",
-           plugin_path);
+  snprintf(out, out_size, "%s/../backends/jpeg2000/%s", plugin_path, soname);
 }
 #endif
 
-static const h5z_jpeg2000_backend_t *load_kakadu_backend(void) {
-#ifndef _WIN32
-  static int tried = 0;
-  static const h5z_jpeg2000_backend_t *backend = NULL;
-  static void *handle = NULL;
-  if (tried) {
-    return backend;
-  }
-  tried = 1;
+static int is_dynamic_backend_name(const char *name) {
+  return strcmp(name, "openjpeg") == 0 || strcmp(name, "kakadu") == 0;
+}
 
-  const char *env_path = getenv("HDF5PLUGIN_JPEG2000_KAKADU_BACKEND_PATH");
+static const h5z_jpeg2000_backend_t *load_dynamic_backend(const char *name) {
+#ifndef _WIN32
+  static int tried_openjpeg = 0;
+  static int tried_kakadu = 0;
+  static const h5z_jpeg2000_backend_t *openjpeg_backend = NULL;
+  static const h5z_jpeg2000_backend_t *kakadu_backend = NULL;
+  static void *openjpeg_handle = NULL;
+  static void *kakadu_handle = NULL;
+
+  int *tried = NULL;
+  const h5z_jpeg2000_backend_t **backend = NULL;
+  void **handle = NULL;
+  if (strcmp(name, "openjpeg") == 0) {
+    tried = &tried_openjpeg;
+    backend = &openjpeg_backend;
+    handle = &openjpeg_handle;
+  } else if (strcmp(name, "kakadu") == 0) {
+    tried = &tried_kakadu;
+    backend = &kakadu_backend;
+    handle = &kakadu_handle;
+  } else {
+    return NULL;
+  }
+
+  if (*tried) {
+    return *backend;
+  }
+  *tried = 1;
+
+  char env_name[128];
+  snprintf(env_name, sizeof(env_name), "HDF5PLUGIN_JPEG2000_%s_BACKEND_PATH", name);
+  for (char *p = env_name; *p != '\0'; ++p) {
+    if (*p >= 'a' && *p <= 'z') {
+      *p = (char)(*p - 'a' + 'A');
+    }
+  }
+
+  const char *env_path = getenv(env_name);
   char relative_path[4096];
-  make_backend_path(relative_path, sizeof(relative_path));
+  char soname[128];
+  snprintf(soname, sizeof(soname), "libh5jpeg2000_%s_backend.so", name);
+  make_backend_path(relative_path, sizeof(relative_path), soname);
 
   const char *candidates[4];
   int candidate_count = 0;
@@ -77,32 +108,35 @@ static const h5z_jpeg2000_backend_t *load_kakadu_backend(void) {
   if (relative_path[0] != '\0') {
     candidates[candidate_count++] = relative_path;
   }
-  candidates[candidate_count++] = "libh5jpeg2000_kakadu_backend.so";
+  candidates[candidate_count++] = soname;
   candidates[candidate_count] = NULL;
 
+  char symbol[128];
+  snprintf(symbol, sizeof(symbol), "h5z_jpeg2000_%s_backend", name);
+
   for (int i = 0; candidates[i] != NULL; i++) {
-    handle = dlopen(candidates[i], RTLD_NOW | RTLD_LOCAL);
-    if (handle == NULL) {
+    *handle = dlopen(candidates[i], RTLD_NOW | RTLD_LOCAL);
+    if (*handle == NULL) {
       if (jpeg2000_debug_enabled()) {
-        fprintf(stderr, "jpeg2000: could not load Kakadu backend '%s': %s\n",
-                candidates[i], dlerror());
+        fprintf(stderr, "jpeg2000: could not load %s backend '%s': %s\n",
+                name, candidates[i], dlerror());
       }
       continue;
     }
-    backend = (const h5z_jpeg2000_backend_t *)dlsym(
-        handle, "h5z_jpeg2000_kakadu_backend");
-    if (backend != NULL && backend->name != NULL &&
-        strcmp(backend->name, "kakadu") == 0) {
-      return backend;
+    *backend = (const h5z_jpeg2000_backend_t *)dlsym(*handle, symbol);
+    if (*backend != NULL && (*backend)->name != NULL &&
+        strcmp((*backend)->name, name) == 0) {
+      return *backend;
     }
     if (jpeg2000_debug_enabled()) {
-      fprintf(stderr, "jpeg2000: invalid Kakadu backend '%s'\n", candidates[i]);
+      fprintf(stderr, "jpeg2000: invalid %s backend '%s'\n", name, candidates[i]);
     }
-    dlclose(handle);
-    handle = NULL;
-    backend = NULL;
+    dlclose(*handle);
+    *handle = NULL;
+    *backend = NULL;
   }
 #else
+  (void)name;
   (void)jpeg2000_debug_enabled;
 #endif
   return NULL;
@@ -115,8 +149,8 @@ static const h5z_jpeg2000_backend_t *find_backend(const char *name) {
       return backend;
     }
   }
-  if (strcmp(name, "kakadu") == 0) {
-    return load_kakadu_backend();
+  if (is_dynamic_backend_name(name)) {
+    return load_dynamic_backend(name);
   }
   return NULL;
 }
@@ -125,6 +159,14 @@ static const h5z_jpeg2000_backend_t *first_available_backend(void) {
   for (int i = 0; builtin_backends[i] != NULL; i++) {
     const h5z_jpeg2000_backend_t *backend = builtin_backends[i];
     if (backend->available()) {
+      return backend;
+    }
+  }
+
+  const char *dynamic_defaults[] = {"kakadu", "openjpeg", NULL};
+  for (int i = 0; dynamic_defaults[i] != NULL; i++) {
+    const h5z_jpeg2000_backend_t *backend = load_dynamic_backend(dynamic_defaults[i]);
+    if (backend != NULL && backend->available()) {
       return backend;
     }
   }

--- a/lib/H5Z-jpeg2000/backends/registry.c
+++ b/lib/H5Z-jpeg2000/backends/registry.c
@@ -1,13 +1,23 @@
+#ifndef _WIN32
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#endif
+
 #include "H5Zjpeg2000_backend.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
+#ifndef _WIN32
+#include <dlfcn.h>
+#endif
+
 #define MAX_MANIFEST_BACKENDS 16
 #define MAX_BACKEND_NAME_LEN 64
 
-static const h5z_jpeg2000_backend_t *const available_backends[] = {
+static const h5z_jpeg2000_backend_t *const builtin_backends[] = {
     &h5z_jpeg2000_openjpeg_backend,
     NULL,
 };
@@ -18,19 +28,102 @@ typedef struct {
   char error[256];
 } manifest_priority_t;
 
+
+static int jpeg2000_debug_enabled(void) {
+  const char *debug = getenv("HDF5PLUGIN_JPEG2000_DEBUG");
+  return debug != NULL && debug[0] != '\0';
+}
+
+#ifndef _WIN32
+static void make_backend_path(char *out, size_t out_size) {
+  Dl_info info;
+  out[0] = '\0';
+  if (dladdr((void *)&h5z_jpeg2000_select_backend, &info) == 0 ||
+      info.dli_fname == NULL) {
+    return;
+  }
+
+  char plugin_path[4096];
+  snprintf(plugin_path, sizeof(plugin_path), "%s", info.dli_fname);
+  char *slash = strrchr(plugin_path, '/');
+  if (slash == NULL) {
+    return;
+  }
+  *slash = '\0';
+  snprintf(out, out_size, "%s/../backends/jpeg2000/libh5jpeg2000_kakadu_backend.so",
+           plugin_path);
+}
+#endif
+
+static const h5z_jpeg2000_backend_t *load_kakadu_backend(void) {
+#ifndef _WIN32
+  static int tried = 0;
+  static const h5z_jpeg2000_backend_t *backend = NULL;
+  static void *handle = NULL;
+  if (tried) {
+    return backend;
+  }
+  tried = 1;
+
+  const char *env_path = getenv("HDF5PLUGIN_JPEG2000_KAKADU_BACKEND_PATH");
+  char relative_path[4096];
+  make_backend_path(relative_path, sizeof(relative_path));
+
+  const char *candidates[4];
+  int candidate_count = 0;
+  if (env_path != NULL && env_path[0] != '\0') {
+    candidates[candidate_count++] = env_path;
+  }
+  if (relative_path[0] != '\0') {
+    candidates[candidate_count++] = relative_path;
+  }
+  candidates[candidate_count++] = "libh5jpeg2000_kakadu_backend.so";
+  candidates[candidate_count] = NULL;
+
+  for (int i = 0; candidates[i] != NULL; i++) {
+    handle = dlopen(candidates[i], RTLD_NOW | RTLD_LOCAL);
+    if (handle == NULL) {
+      if (jpeg2000_debug_enabled()) {
+        fprintf(stderr, "jpeg2000: could not load Kakadu backend '%s': %s\n",
+                candidates[i], dlerror());
+      }
+      continue;
+    }
+    backend = (const h5z_jpeg2000_backend_t *)dlsym(
+        handle, "h5z_jpeg2000_kakadu_backend");
+    if (backend != NULL && backend->name != NULL &&
+        strcmp(backend->name, "kakadu") == 0) {
+      return backend;
+    }
+    if (jpeg2000_debug_enabled()) {
+      fprintf(stderr, "jpeg2000: invalid Kakadu backend '%s'\n", candidates[i]);
+    }
+    dlclose(handle);
+    handle = NULL;
+    backend = NULL;
+  }
+#else
+  (void)jpeg2000_debug_enabled;
+#endif
+  return NULL;
+}
+
 static const h5z_jpeg2000_backend_t *find_backend(const char *name) {
-  for (int i = 0; available_backends[i] != NULL; i++) {
-    const h5z_jpeg2000_backend_t *backend = available_backends[i];
+  for (int i = 0; builtin_backends[i] != NULL; i++) {
+    const h5z_jpeg2000_backend_t *backend = builtin_backends[i];
     if (strcmp(name, backend->name) == 0) {
       return backend;
     }
+  }
+  if (strcmp(name, "kakadu") == 0) {
+    return load_kakadu_backend();
   }
   return NULL;
 }
 
 static const h5z_jpeg2000_backend_t *first_available_backend(void) {
-  for (int i = 0; available_backends[i] != NULL; i++) {
-    const h5z_jpeg2000_backend_t *backend = available_backends[i];
+  for (int i = 0; builtin_backends[i] != NULL; i++) {
+    const h5z_jpeg2000_backend_t *backend = builtin_backends[i];
     if (backend->available()) {
       return backend;
     }

--- a/lib/H5Z-jpeg2000/backends/registry.c
+++ b/lib/H5Z-jpeg2000/backends/registry.c
@@ -17,6 +17,11 @@
 #define MAX_MANIFEST_BACKENDS 16
 #define MAX_BACKEND_NAME_LEN 64
 
+/*
+ * Keep this table for ABI symmetry with possible future built-in backends, but
+ * the current J2K filter intentionally ships no backend in libh5jpeg2000.so.
+ * OpenJPEG and Kakadu are both optional shared libraries loaded at runtime.
+ */
 static const h5z_jpeg2000_backend_t *const builtin_backends[] = {
     NULL,
 };
@@ -34,6 +39,16 @@ static int jpeg2000_debug_enabled(void) {
 }
 
 #ifndef _WIN32
+/*
+ * Backends installed by this package live next to the HDF5 plugin, under a
+ * plugin-specific directory:
+ *
+ *   hdf5plugin/plugins/libh5jpeg2000.so
+ *   hdf5plugin/backends/jpeg2000/libh5jpeg2000_<name>_backend.so
+ *
+ * This relative lookup keeps the Python package relocatable while avoiding any
+ * direct link from the HDF5 filter to backend-specific dependencies.
+ */
 static void make_backend_path(char *out, size_t out_size, const char *soname) {
   Dl_info info;
   out[0] = '\0';
@@ -94,6 +109,12 @@ static const h5z_jpeg2000_backend_t *load_dynamic_backend(const char *name) {
     }
   }
 
+  /*
+   * Candidate order:
+   * 1. explicit per-backend override, useful for local experiments;
+   * 2. packaged backend next to the plugin;
+   * 3. dynamic loader search path, useful for externally installed backends.
+   */
   const char *env_path = getenv(env_name);
   char relative_path[4096];
   char soname[128];
@@ -163,6 +184,12 @@ static const h5z_jpeg2000_backend_t *first_available_backend(void) {
     }
   }
 
+  /*
+   * Last-resort policy when neither env var nor manifest selects a backend.
+   * Prefer Kakadu when available in this development branch; OpenJPEG remains a
+   * fully dynamic fallback on machines where its development package was
+   * available at build time.
+   */
   const char *dynamic_defaults[] = {"kakadu", "openjpeg", NULL};
   for (int i = 0; dynamic_defaults[i] != NULL; i++) {
     const h5z_jpeg2000_backend_t *backend = load_dynamic_backend(dynamic_defaults[i]);

--- a/lib/H5Z-jpeg2000/backends/registry.c
+++ b/lib/H5Z-jpeg2000/backends/registry.c
@@ -1,0 +1,317 @@
+#include "H5Zjpeg2000_backend.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MAX_MANIFEST_BACKENDS 16
+#define MAX_BACKEND_NAME_LEN 64
+
+static const h5z_jpeg2000_backend_t *const available_backends[] = {
+    &h5z_jpeg2000_openjpeg_backend,
+    NULL,
+};
+
+typedef struct {
+  char names[MAX_MANIFEST_BACKENDS][MAX_BACKEND_NAME_LEN];
+  int count;
+  char error[256];
+} manifest_priority_t;
+
+static const h5z_jpeg2000_backend_t *find_backend(const char *name) {
+  for (int i = 0; available_backends[i] != NULL; i++) {
+    const h5z_jpeg2000_backend_t *backend = available_backends[i];
+    if (strcmp(name, backend->name) == 0) {
+      return backend;
+    }
+  }
+  return NULL;
+}
+
+static const h5z_jpeg2000_backend_t *first_available_backend(void) {
+  for (int i = 0; available_backends[i] != NULL; i++) {
+    const h5z_jpeg2000_backend_t *backend = available_backends[i];
+    if (backend->available()) {
+      return backend;
+    }
+  }
+  return NULL;
+}
+
+static void skip_json_ws(const char *text, size_t len, size_t *pos) {
+  while (*pos < len && (text[*pos] == ' ' || text[*pos] == '\n' ||
+                        text[*pos] == '\r' || text[*pos] == '\t')) {
+    (*pos)++;
+  }
+}
+
+static int parse_json_string_at(const char *text, size_t len, size_t *pos,
+                                char *out, size_t out_size) {
+  size_t out_pos = 0;
+  skip_json_ws(text, len, pos);
+  if (*pos >= len || text[*pos] != '"') {
+    return 0;
+  }
+  (*pos)++;
+  while (*pos < len) {
+    char c = text[(*pos)++];
+    if (c == '"') {
+      if (out_size > 0) {
+        out[out_pos < out_size ? out_pos : out_size - 1] = '\0';
+      }
+      return 1;
+    }
+    if (c == '\\') {
+      if (*pos >= len) {
+        return 0;
+      }
+      c = text[(*pos)++];
+      switch (c) {
+      case '"':
+      case '\\':
+      case '/':
+        break;
+      case 'b':
+        c = '\b';
+        break;
+      case 'f':
+        c = '\f';
+        break;
+      case 'n':
+        c = '\n';
+        break;
+      case 'r':
+        c = '\r';
+        break;
+      case 't':
+        c = '\t';
+        break;
+      default:
+        return 0;
+      }
+    }
+    if (out_pos + 1 < out_size) {
+      out[out_pos++] = c;
+    }
+  }
+  return 0;
+}
+
+static size_t find_json_key(const char *text, size_t len, const char *key) {
+  char quoted_key[128];
+  int written = snprintf(quoted_key, sizeof(quoted_key), "\"%s\"", key);
+  if (written <= 0 || (size_t)written >= sizeof(quoted_key)) {
+    return (size_t)-1;
+  }
+
+  const size_t key_len = (size_t)written;
+  for (size_t pos = 0; pos + key_len <= len; pos++) {
+    if (memcmp(text + pos, quoted_key, key_len) != 0) {
+      continue;
+    }
+    size_t after_key = pos + key_len;
+    skip_json_ws(text, len, &after_key);
+    if (after_key < len && text[after_key] == ':') {
+      return after_key + 1;
+    }
+  }
+  return (size_t)-1;
+}
+
+static int parse_json_string_field(const char *text, size_t len, const char *key,
+                                   char *out, size_t out_size) {
+  size_t pos = find_json_key(text, len, key);
+  if (pos == (size_t)-1) {
+    return 0;
+  }
+  return parse_json_string_at(text, len, &pos, out, out_size);
+}
+
+static int append_manifest_backend(manifest_priority_t *priority,
+                                   const char *name) {
+  if (name[0] == '\0') {
+    return 1;
+  }
+  if (priority->count >= MAX_MANIFEST_BACKENDS) {
+    snprintf(priority->error, sizeof(priority->error),
+             "too many backend entries in jpeg2000 manifest");
+    return 0;
+  }
+  snprintf(priority->names[priority->count], MAX_BACKEND_NAME_LEN, "%s", name);
+  priority->count++;
+  return 1;
+}
+
+static int parse_json_string_array_field(const char *text, size_t len,
+                                         const char *key,
+                                         manifest_priority_t *priority) {
+  size_t pos = find_json_key(text, len, key);
+  if (pos == (size_t)-1) {
+    return 1;
+  }
+  skip_json_ws(text, len, &pos);
+  if (pos >= len || text[pos] != '[') {
+    snprintf(priority->error, sizeof(priority->error),
+             "manifest field '%s' is not an array", key);
+    return 0;
+  }
+  pos++;
+  while (pos < len) {
+    skip_json_ws(text, len, &pos);
+    if (pos < len && text[pos] == ']') {
+      return 1;
+    }
+    char value[MAX_BACKEND_NAME_LEN] = {0};
+    if (!parse_json_string_at(text, len, &pos, value, sizeof(value))) {
+      snprintf(priority->error, sizeof(priority->error),
+               "manifest field '%s' contains a non-string entry", key);
+      return 0;
+    }
+    if (!append_manifest_backend(priority, value)) {
+      return 0;
+    }
+    skip_json_ws(text, len, &pos);
+    if (pos < len && text[pos] == ',') {
+      pos++;
+      continue;
+    }
+    if (pos < len && text[pos] == ']') {
+      return 1;
+    }
+    snprintf(priority->error, sizeof(priority->error),
+             "manifest field '%s' has invalid array syntax", key);
+    return 0;
+  }
+  snprintf(priority->error, sizeof(priority->error),
+           "manifest field '%s' has an unterminated array", key);
+  return 0;
+}
+
+static char *read_text_file(const char *path, size_t *len) {
+  FILE *file = fopen(path, "rb");
+  if (file == NULL) {
+    return NULL;
+  }
+  if (fseek(file, 0, SEEK_END) != 0) {
+    fclose(file);
+    return NULL;
+  }
+  long size = ftell(file);
+  if (size < 0) {
+    fclose(file);
+    return NULL;
+  }
+  if (fseek(file, 0, SEEK_SET) != 0) {
+    fclose(file);
+    return NULL;
+  }
+  char *text = (char *)malloc((size_t)size + 1);
+  if (text == NULL) {
+    fclose(file);
+    return NULL;
+  }
+  size_t read_len = fread(text, 1, (size_t)size, file);
+  fclose(file);
+  text[read_len] = '\0';
+  *len = read_len;
+  return text;
+}
+
+static int load_manifest_priority(manifest_priority_t *priority) {
+  const char *path = getenv(H5Z_JPEG2000_MANIFEST_ENV);
+  if (path == NULL || path[0] == '\0') {
+    return 1;
+  }
+
+  size_t len = 0;
+  char *text = read_text_file(path, &len);
+  if (text == NULL) {
+    snprintf(priority->error, sizeof(priority->error),
+             "could not open jpeg2000 manifest '%s'", path);
+    return 0;
+  }
+
+  char backend[MAX_BACKEND_NAME_LEN] = {0};
+  if (parse_json_string_field(text, len, "backend", backend, sizeof(backend))) {
+    if (!append_manifest_backend(priority, backend)) {
+      free(text);
+      return 0;
+    }
+  }
+
+  int ok = parse_json_string_array_field(text, len, "jpeg2000", priority);
+  free(text);
+  return ok;
+}
+
+static const h5z_jpeg2000_backend_t *select_named_backend(const char *name) {
+  const h5z_jpeg2000_backend_t *backend = find_backend(name);
+  if (backend == NULL) {
+    fprintf(stderr, "Unsupported jpeg2000 backend '%s'\n", name);
+    return NULL;
+  }
+  if (!backend->available()) {
+    fprintf(stderr, "Requested jpeg2000 backend '%s' is not available\n", name);
+    return NULL;
+  }
+  return backend;
+}
+
+static const h5z_jpeg2000_backend_t *select_manifest_backend(void) {
+  manifest_priority_t priority;
+  memset(&priority, 0, sizeof(priority));
+  if (!load_manifest_priority(&priority)) {
+    fprintf(stderr, "Invalid jpeg2000 manifest: %s\n", priority.error);
+    return NULL;
+  }
+  for (int i = 0; i < priority.count; i++) {
+    const h5z_jpeg2000_backend_t *backend = find_backend(priority.names[i]);
+    if (backend != NULL && backend->available()) {
+      return backend;
+    }
+  }
+  return NULL;
+}
+
+const h5z_jpeg2000_backend_t *h5z_jpeg2000_select_backend(void) {
+  const char *requested = getenv(H5Z_JPEG2000_BACKEND_ENV);
+
+  if (requested != NULL && requested[0] != '\0' && strcmp(requested, "auto") != 0) {
+    return select_named_backend(requested);
+  }
+
+  const h5z_jpeg2000_backend_t *backend = select_manifest_backend();
+  if (backend != NULL) {
+    return backend;
+  }
+
+  backend = first_available_backend();
+  if (backend == NULL) {
+    fprintf(stderr, "No jpeg2000 backend is available\n");
+  }
+  return backend;
+}
+
+int h5z_jpeg2000_compress(size_t input_nbytes, void *input_buffer,
+                          unsigned int width, unsigned int height,
+                          unsigned int ncomps, unsigned int dtype,
+                          float compression_ratio, size_t *output_nbytes,
+                          void **output_buffer) {
+  const h5z_jpeg2000_backend_t *backend = h5z_jpeg2000_select_backend();
+  if (backend == NULL) {
+    return -1;
+  }
+  return backend->compress(input_nbytes, input_buffer, width, height, ncomps,
+                           dtype, compression_ratio, output_nbytes,
+                           output_buffer);
+}
+
+int h5z_jpeg2000_decompress(size_t compressed_nbytes, void *compressed_buffer,
+                            size_t *output_nbytes, void **output_buffer) {
+  const h5z_jpeg2000_backend_t *backend = h5z_jpeg2000_select_backend();
+  if (backend == NULL) {
+    return -1;
+  }
+  return backend->decompress(compressed_nbytes, compressed_buffer, output_nbytes,
+                             output_buffer);
+}

--- a/lib/H5Z-jpeg2000/opj_compress.c
+++ b/lib/H5Z-jpeg2000/opj_compress.c
@@ -167,10 +167,10 @@ static void on_info(const char *msg, void *data) {
 /* Public API                                                          */
 /* ------------------------------------------------------------------ */
 
-int compress(size_t input_nbytes, void *input_buffer, unsigned int width,
-             unsigned int height, unsigned int ncomps, unsigned int dtype,
-             float compression_ratio, size_t *output_nbytes,
-             void **output_buffer) {
+int h5z_jpeg2000_openjpeg_compress(
+    size_t input_nbytes, void *input_buffer, unsigned int width,
+    unsigned int height, unsigned int ncomps, unsigned int dtype,
+    float compression_ratio, size_t *output_nbytes, void **output_buffer) {
   int ret = -1;
   opj_codec_t *codec = NULL;
   opj_stream_t *stream = NULL;

--- a/lib/H5Z-jpeg2000/opj_decompress.c
+++ b/lib/H5Z-jpeg2000/opj_decompress.c
@@ -171,8 +171,10 @@ static int pack_samples(const opj_image_t *image, const image_info_t *info,
 /* Public API                                                          */
 /* ------------------------------------------------------------------ */
 
-int decompress(size_t compressed_nbytes, void *compressed_buffer,
-               size_t *output_nbytes, void **output_buffer) {
+int h5z_jpeg2000_openjpeg_decompress(size_t compressed_nbytes,
+                                     void *compressed_buffer,
+                                     size_t *output_nbytes,
+                                     void **output_buffer) {
   int ret = -1;
   opj_codec_t *codec = NULL;
   opj_stream_t *stream = NULL;
@@ -186,7 +188,10 @@ int decompress(size_t compressed_nbytes, void *compressed_buffer,
   *output_nbytes = 0;
   *output_buffer = NULL;
 
-  /* ---- 1. Create J2K decoder (handles J2K, JP2 and HTJ2K) ---- */
+  /* ---- 1. Create J2K/JP2 decoder ----
+   * This plugin currently targets J2K only. HTJ2K support, if added,
+   * will be evaluated separately and possibly live in its own plugin.
+   */
   OPJ_CODEC_FORMAT format;
   if (compressed_nbytes < 4) {
     fprintf(stderr, "Input too short to determine codestream format\n");

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,12 @@ dev = [
 packages = ["hdf5plugin"]
 package-dir = {"" = "src"}
 
+[tool.setuptools.package-data]
+# Ship backend manifests such as hdf5plugin_jpeg2000_plugins.json in wheels,
+# so runtime backend selection works after pip install, not only from source.
+# Keep py.typed packaged too; it marks hdf5plugin as typed for PEP 561 tools.
+hdf5plugin = ["*.json", "py.typed"]
+
 [tool.setuptools.dynamic]
 version = {attr = "hdf5plugin._version.version"}
 

--- a/setup.py
+++ b/setup.py
@@ -1326,20 +1326,108 @@ def _get_lz4_plugin():
 PLUGIN_LIB_DEPENDENCIES["lz4"] = ("lz4",)
 
 
+KAKADU_DEFAULT_ROOT = "/data/scisofttmp/mirone/KD"
+
+
+def _find_kakadu_include_dir(root):
+    """Return a Kakadu include directory, or None when Kakadu is unavailable."""
+    candidates = [os.environ.get("KAKADU_INCLUDE_DIR")]
+    if root:
+        candidates.extend(
+            [
+                os.path.join(root, "managed", "all_includes"),
+                os.path.join(root, "all_includes"),
+                os.path.join(root, "include"),
+                root,
+            ]
+        )
+    for candidate in candidates:
+        if candidate and os.path.exists(os.path.join(candidate, "kdu_stripe_compressor.h")):
+            return candidate
+    return None
+
+
+def _find_kakadu_library_name(library_dir, names):
+    """Return the linker name for the first Kakadu library found."""
+    suffixes = (".so", ".dylib", ".a")
+    for name in names:
+        for suffix in suffixes:
+            if os.path.exists(os.path.join(library_dir, f"lib{name}{suffix}")):
+                return name
+        if sys.platform == "win32" and os.path.exists(os.path.join(library_dir, f"{name}.lib")):
+            return name
+    return None
+
+
+def _get_kakadu_config():
+    """Return optional Kakadu build configuration for the JPEG2000 backend."""
+    root = os.environ.get("KAKADU_ROOT") or os.environ.get("KDIR") or KAKADU_DEFAULT_ROOT
+    library_dir = (
+        os.environ.get("KAKADU_LIBRARY_DIR")
+        or os.environ.get("KAKADU_LIB_PATH")
+        or (os.path.join(root, "lib") if root else None)
+    )
+    include_dir = _find_kakadu_include_dir(root)
+
+    if not include_dir or not library_dir or not os.path.isdir(library_dir):
+        logger.info("Kakadu JPEG2000 backend not built: headers/libraries not found")
+        return None
+
+    core = _find_kakadu_library_name(
+        library_dir,
+        ("kdu_v86R", "kdu_v85R", "kdu_v84R", "kdu_v83R", "kdu_v82R", "kdu_v81R", "kdu_v80R", "kdu"),
+    )
+    aux = _find_kakadu_library_name(
+        library_dir,
+        ("kdu_a86R", "kdu_a85R", "kdu_a84R", "kdu_a83R", "kdu_a82R", "kdu_a81R", "kdu_a80R", "kdu_aux"),
+    )
+    if not core or not aux:
+        logger.info("Kakadu JPEG2000 backend not built: kdu/kdu_aux libraries not found")
+        return None
+
+    extra_link_args = ["-lstdc++"] if sys.platform != "win32" else []
+
+    logger.info("Building Kakadu JPEG2000 backend from %s", root)
+    return {
+        "include_dir": include_dir,
+        "library_dir": library_dir,
+        "libraries": [core, aux],
+        "extra_link_args": extra_link_args,
+    }
+
+
+def _get_jpeg2000_kakadu_backend(h5jpeg2000_dir, kakadu_config):
+    """Optional Kakadu backend shared library loaded by the JPEG2000 filter."""
+    return Extension(
+        "hdf5plugin.backends.jpeg2000.libh5jpeg2000_kakadu_backend",
+        sources=[f"{h5jpeg2000_dir}/backends/kakadu.cpp"],
+        include_dirs=[h5jpeg2000_dir, kakadu_config["include_dir"]],
+        define_macros=[("H5Z_JPEG2000_HAVE_KAKADU", 1)],
+        extra_compile_args=["-std=c++11"],
+        extra_link_args=kakadu_config["extra_link_args"],
+        libraries=kakadu_config["libraries"],
+        library_dirs=[kakadu_config["library_dir"]],
+        export_symbols=["h5z_jpeg2000_kakadu_backend"],
+    )
+
+
 def _get_jpeg2000_plugin():
     """Jpeg2000 plugin build config"""
     h5jpeg2000_dir = "lib/H5Z-jpeg2000"
+    extensions = [
+        HDF5PluginExtension(
+            "hdf5plugin.plugins.libh5jpeg2000",
+            sources=glob(f"{h5jpeg2000_dir}/*.c") + glob(f"{h5jpeg2000_dir}/backends/*.c"),
+            include_dirs=[h5jpeg2000_dir] + get_clib_config("openjp2", "include_dirs"),
+            extra_link_args=get_clib_config("openjp2", "extra_link_args"),
+            libraries=get_clib_config("openjp2", "libraries"),
+        )
+    ]
 
-    return HDF5PluginExtension(
-        "hdf5plugin.plugins.libh5jpeg2000",
-        sources=(
-            glob(f"{h5jpeg2000_dir}/*.c")
-            + glob(f"{h5jpeg2000_dir}/backends/*.c")
-        ),
-        include_dirs=[h5jpeg2000_dir] + get_clib_config("openjp2", "include_dirs"),
-        extra_link_args=get_clib_config("openjp2", "extra_link_args"),
-        libraries=get_clib_config("openjp2", "libraries"),
-    )
+    kakadu_config = _get_kakadu_config()
+    if kakadu_config is not None:
+        extensions.append(_get_jpeg2000_kakadu_backend(h5jpeg2000_dir, kakadu_config))
+    return extensions
 
 
 PLUGIN_LIB_DEPENDENCIES["jpeg2000"] = ()
@@ -1561,11 +1649,16 @@ def get_libraries_and_extensions():
         if name not in get_system_clib_names()
     ]
 
-    # Create Python extensions
+    # Create Python extensions.  Some filter factories can return more than one
+    # extension, e.g. the JPEG2000 HDF5 filter plus optional backend libraries.
     embedded_extension_names = PLUGIN_NAMES - stripped_filters
-    extensions = [
-        _EMBEDDED_PLUGIN_EXTENSIONS[name]() for name in embedded_extension_names
-    ]
+    extensions = []
+    for name in embedded_extension_names:
+        extension_or_extensions = _EMBEDDED_PLUGIN_EXTENSIONS[name]()
+        if isinstance(extension_or_extensions, (list, tuple)):
+            extensions.extend(extension_or_extensions)
+        else:
+            extensions.append(extension_or_extensions)
 
     if extensions and sys.platform != "win32":
         # Add hdf5 dynamic loading lib

--- a/setup.py
+++ b/setup.py
@@ -1332,14 +1332,17 @@ def _get_jpeg2000_plugin():
 
     return HDF5PluginExtension(
         "hdf5plugin.plugins.libh5jpeg2000",
-        sources=glob(f"{h5jpeg2000_dir}/*.c"),
+        sources=(
+            glob(f"{h5jpeg2000_dir}/*.c")
+            + glob(f"{h5jpeg2000_dir}/backends/*.c")
+        ),
         include_dirs=[h5jpeg2000_dir] + get_clib_config("openjp2", "include_dirs"),
         extra_link_args=get_clib_config("openjp2", "extra_link_args"),
         libraries=get_clib_config("openjp2", "libraries"),
     )
 
 
-PLUGIN_LIB_DEPENDENCIES["jpeg200"] = ()
+PLUGIN_LIB_DEPENDENCIES["jpeg2000"] = ()
 
 
 def _get_bzip2_plugin():

--- a/setup.py
+++ b/setup.py
@@ -1359,6 +1359,19 @@ def _find_kakadu_library_name(library_dir, names):
     return None
 
 
+def _get_openjpeg_config():
+    """Return optional OpenJPEG build configuration for the JPEG2000 backend."""
+    try:
+        return {
+            "include_dirs": get_clib_config("openjp2", "include_dirs"),
+            "extra_link_args": get_clib_config("openjp2", "extra_link_args"),
+            "libraries": get_clib_config("openjp2", "libraries"),
+        }
+    except RuntimeError as exc:
+        logger.info("OpenJPEG JPEG2000 backend not built: %s", exc)
+        return None
+
+
 def _get_kakadu_config():
     """Return optional Kakadu build configuration for the JPEG2000 backend."""
     root = os.environ.get("KAKADU_ROOT") or os.environ.get("KDIR") or KAKADU_DEFAULT_ROOT
@@ -1396,6 +1409,22 @@ def _get_kakadu_config():
     }
 
 
+def _get_jpeg2000_openjpeg_backend(h5jpeg2000_dir, openjpeg_config):
+    """Optional OpenJPEG backend shared library loaded by the JPEG2000 filter."""
+    return Extension(
+        "hdf5plugin.backends.jpeg2000.libh5jpeg2000_openjpeg_backend",
+        sources=[
+            f"{h5jpeg2000_dir}/opj_compress.c",
+            f"{h5jpeg2000_dir}/opj_decompress.c",
+            f"{h5jpeg2000_dir}/backends/openjpeg.c",
+        ],
+        include_dirs=[h5jpeg2000_dir] + openjpeg_config["include_dirs"],
+        extra_link_args=openjpeg_config["extra_link_args"],
+        libraries=openjpeg_config["libraries"],
+        export_symbols=["h5z_jpeg2000_openjpeg_backend"],
+    )
+
+
 def _get_jpeg2000_kakadu_backend(h5jpeg2000_dir, kakadu_config):
     """Optional Kakadu backend shared library loaded by the JPEG2000 filter."""
     return Extension(
@@ -1417,12 +1446,18 @@ def _get_jpeg2000_plugin():
     extensions = [
         HDF5PluginExtension(
             "hdf5plugin.plugins.libh5jpeg2000",
-            sources=glob(f"{h5jpeg2000_dir}/*.c") + glob(f"{h5jpeg2000_dir}/backends/*.c"),
-            include_dirs=[h5jpeg2000_dir] + get_clib_config("openjp2", "include_dirs"),
-            extra_link_args=get_clib_config("openjp2", "extra_link_args"),
-            libraries=get_clib_config("openjp2", "libraries"),
+            sources=[
+                f"{h5jpeg2000_dir}/H5Zjpeg2000.c",
+                f"{h5jpeg2000_dir}/backends/registry.c",
+            ],
+            include_dirs=[h5jpeg2000_dir],
+            extra_link_args=["-ldl"] if sys.platform != "win32" else [],
         )
     ]
+
+    openjpeg_config = _get_openjpeg_config()
+    if openjpeg_config is not None:
+        extensions.append(_get_jpeg2000_openjpeg_backend(h5jpeg2000_dir, openjpeg_config))
 
     kakadu_config = _get_kakadu_config()
     if kakadu_config is not None:

--- a/src/hdf5plugin/_filters.py
+++ b/src/hdf5plugin/_filters.py
@@ -566,7 +566,7 @@ class Jpeg2000(FilterBase):
     _BACKEND_ENVVAR = "HDF5PLUGIN_JPEG2000_BACKEND"
     _MANIFEST_ENVVAR = "HDF5PLUGIN_JPEG2000_MANIFEST"
     _DEFAULT_MANIFEST_NAME = "hdf5plugin_jpeg2000_plugins.json"
-    _BackendType = Literal["auto", "openjpeg"]
+    _BackendType = Literal["auto", "openjpeg", "kakadu"]
 
     @classmethod
     def default_manifest_path(cls) -> str:
@@ -597,7 +597,7 @@ class Jpeg2000(FilterBase):
         preference for the current process before HDF5 invokes the filter. The
         explicit backend takes precedence over the manifest.
         """
-        if backend not in ("auto", "openjpeg"):
+        if backend not in ("auto", "openjpeg", "kakadu"):
             raise ValueError(f"Unsupported jpeg2000 backend: {backend!r}")
         if backend == "auto":
             os.environ.pop(cls._BACKEND_ENVVAR, None)

--- a/src/hdf5plugin/_filters.py
+++ b/src/hdf5plugin/_filters.py
@@ -25,7 +25,9 @@ from __future__ import annotations
 
 import logging
 import math
+import os
 import struct
+from pathlib import Path
 from collections.abc import Mapping
 from typing import Literal, TypeVar
 
@@ -549,13 +551,58 @@ class Jpeg2000(FilterBase):
         f.close()
 
     :param compression_ratio: Raw data/Compressed data size ratio.
-        Compression ratio of 1 means lossless compression
+        Compression ratio of 1 means lossless compression.
+
+    The native backend can be selected at runtime with
+    :meth:`Jpeg2000.configure_backend` or the
+    ``HDF5PLUGIN_JPEG2000_BACKEND`` environment variable. This setting is not
+    stored in the HDF5 file.
     """
 
     filter_name = "jpeg2000"
     filter_id = 65000  # TODO
 
     _FIXED_POINT_FACTOR = 100.0
+    _BACKEND_ENVVAR = "HDF5PLUGIN_JPEG2000_BACKEND"
+    _MANIFEST_ENVVAR = "HDF5PLUGIN_JPEG2000_MANIFEST"
+    _DEFAULT_MANIFEST_NAME = "hdf5plugin_jpeg2000_plugins.json"
+    _BackendType = Literal["auto", "openjpeg"]
+
+    @classmethod
+    def default_manifest_path(cls) -> str:
+        """Return the packaged jpeg2000 backend manifest path."""
+        return str(Path(__file__).with_name(cls._DEFAULT_MANIFEST_NAME))
+
+    @classmethod
+    def configure_manifest(cls, path: str | os.PathLike[str] | None = None) -> None:
+        """Select the runtime backend manifest used by the native filter.
+
+        Passing ``None`` restores the packaged manifest when it exists, otherwise
+        it clears the manifest environment override.
+        """
+        if path is None:
+            default_path = cls.default_manifest_path()
+            if os.path.exists(default_path):
+                os.environ[cls._MANIFEST_ENVVAR] = default_path
+            else:
+                os.environ.pop(cls._MANIFEST_ENVVAR, None)
+        else:
+            os.environ[cls._MANIFEST_ENVVAR] = os.fspath(path)
+
+    @classmethod
+    def configure_backend(cls, backend: Jpeg2000._BackendType = "auto") -> None:
+        """Select the runtime backend used by the native jpeg2000 filter.
+
+        This does not change the HDF5 file format. It only sets the backend
+        preference for the current process before HDF5 invokes the filter. The
+        explicit backend takes precedence over the manifest.
+        """
+        if backend not in ("auto", "openjpeg"):
+            raise ValueError(f"Unsupported jpeg2000 backend: {backend!r}")
+        if backend == "auto":
+            os.environ.pop(cls._BACKEND_ENVVAR, None)
+        else:
+            os.environ[cls._BACKEND_ENVVAR] = backend
 
     def __init__(self, compression_ratio: float = 1.0):
         compression_ratio = float(compression_ratio)
@@ -1375,3 +1422,12 @@ FILTER_CLASSES: tuple[type[FilterBase], ...] = (
 
 FILTERS: dict[str, int] = {cls.filter_name: cls.filter_id for cls in FILTER_CLASSES}
 """Mapping of provided filter's name to their HDF5 filter ID."""
+
+
+def _configure_default_jpeg2000_manifest() -> None:
+    manifest_path = Jpeg2000.default_manifest_path()
+    if os.path.exists(manifest_path):
+        os.environ.setdefault(Jpeg2000._MANIFEST_ENVVAR, manifest_path)
+
+
+_configure_default_jpeg2000_manifest()

--- a/src/hdf5plugin/hdf5plugin_jpeg2000_plugins.json
+++ b/src/hdf5plugin/hdf5plugin_jpeg2000_plugins.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
   "priority": {
-    "jpeg2000": ["openjpeg"]
+    "jpeg2000": ["kakadu", "openjpeg"]
   }
 }

--- a/src/hdf5plugin/hdf5plugin_jpeg2000_plugins.json
+++ b/src/hdf5plugin/hdf5plugin_jpeg2000_plugins.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "priority": {
+    "jpeg2000": ["openjpeg"]
+  }
+}

--- a/src/hdf5plugin/test.py
+++ b/src/hdf5plugin/test.py
@@ -66,6 +66,7 @@ compression_name_to_class = {
     "bzip2": hdf5plugin.BZip2,
     "lz4": hdf5plugin.LZ4,
     "fcidecomp": hdf5plugin.FciDecomp,
+    "jpeg2000": hdf5plugin.Jpeg2000,
     "sperr": hdf5plugin.Sperr,
     "sz": hdf5plugin.SZ,
     "sz3": hdf5plugin.SZ3,
@@ -917,6 +918,16 @@ class TestRegisterFilter(BaseTestHDF5PluginRW):
     def _simple_test(self, filter_name: str):
         if filter_name == "fcidecomp":
             self._test("fcidecomp", dtype=numpy.uint8)
+        elif filter_name == "jpeg2000":
+            original_natoms = self._data_natoms
+            original_shape = self._data_shape
+            try:
+                self._data_natoms = 64 * 96
+                self._data_shape = (64, 96)
+                self._test("jpeg2000", dtype=numpy.uint16)
+            finally:
+                self._data_natoms = original_natoms
+                self._data_shape = original_shape
         elif filter_name in ("sz", "zfp"):
             self._test(filter_name, dtype=numpy.float32, lossless=False)
         else:


### PR DESCRIPTION
Hi Thomas,

I pushed a new iteration of the JPEG2000 plugin work.

The main design point is that the HDF5 filter itself is now backend-neutral:
`libh5jpeg2000.so` does not link directly to OpenJPEG or Kakadu. It only owns
the HDF5 filter entry point and dispatches compression/decompression to a
runtime backend.

Backends are separate shared libraries, installed for example as:

  hdf5plugin/backends/jpeg2000/libh5jpeg2000_kakadu_backend.so
  hdf5plugin/backends/jpeg2000/libh5jpeg2000_openjpeg_backend.so

This keeps the HDF5 file format independent from the backend used to write the
chunk. A file written with one backend can be read with another compatible
backend, as long as both produce/read standard JPEG2000 codestreams.

I suggest keeping the Kakadu backend in the MR, at least for now, because it is
a useful reference implementation for the backend API and for validating the
multi-backend design. Kakadu is not bundled in the package: the backend is built
only when the headers/libraries are explicitly available, and at runtime the
Kakadu libraries still have to be provided through `LD_LIBRARY_PATH`.

OpenJPEG is treated similarly as an optional backend: it is built only when
`pkg-config` can find `openjp2.pc`.

Backend selection can be done through environment variables:

  HDF5PLUGIN_JPEG2000_BACKEND=kakadu
  HDF5PLUGIN_JPEG2000_BACKEND=openjpeg
  HDF5PLUGIN_JPEG2000_BACKEND=auto

or through the JSON manifest.

From Python, the backend can also be selected programmatically:

  hdf5plugin.Jpeg2000.configure_backend("kakadu")
  hdf5plugin.Jpeg2000.configure_backend("openjpeg")
  hdf5plugin.Jpeg2000.configure_backend("auto")

This currently maps to process-wide environment variables, so the selection is
best treated as a runtime policy normally set once at process startup. It can
technically be changed during the process lifetime, and subsequent filter calls
will use the new policy, but I would not recommend relying on frequent backend
switching in multi-threaded applications.

A backend shared library can also be overridden explicitly, for example with:

  HDF5PLUGIN_JPEG2000_KAKADU_BACKEND_PATH=/path/to/libh5jpeg2000_kakadu_backend.so

For the Kakadu backend, the backend shared library is deliberately not
self-contained. It is built against the Kakadu headers/libraries, but the Kakadu
runtime libraries are not bundled in the Python package or wheel.

Therefore, if `libkdu_*` is not reachable through `LD_LIBRARY_PATH` at runtime,
the Kakadu backend will not be loadable. In `auto` mode the dispatcher will skip
it and try the next available backend, for example OpenJPEG if it was built. If
Kakadu was explicitly requested with `HDF5PLUGIN_JPEG2000_BACKEND=kakadu` or
`hdf5plugin.Jpeg2000.configure_backend("kakadu")`, the operation fails instead
of silently using another backend.

At the moment the registry knows the `kakadu` and `openjpeg` backend names. If
we want truly external third-party backend names, the API is already shaped for
that, but the C registry still needs a small extension to accept arbitrary
backend names or to register additional names.

The only remaining change I am considering for the JPEG2000 filter is adding a
small metadata header before the codestream. The goal is to support a future
float32 mode by storing per-chunk grey-level scaling information together with
the compressed payload, while still keeping the backend codestream itself
standard.

For HTJ2K, my preference is still to keep it as a separate HDF5 plugin. If we
decide not to split J2K and HTJ2K, then I will add a Kakadu HTJ2K backend to the
same backend mechanism.